### PR TITLE
Fix Uno Penalty Repeated on Draw

### DIFF
--- a/Global.-1.ttslua
+++ b/Global.-1.ttslua
@@ -599,9 +599,11 @@ function HideUNO()
     --If someone else other than the player with UNO pressed the button, uno_Called will be true, so we should deal 2 cards to the player with UNO
     if uno_Called == true
     then
+        uno_Called = false
         DealCardsToColor(2,color_Has_Uno)   
     end
     uno_Button_Visible = false
+    color_Has_Uno = nil
     UI.hide("UNO_Button")
 end--Function HideUNO END
 


### PR DESCRIPTION
Unset the uno_Called value when the penalty is met.
This prevents subsequent calls to "HideUNO()" from dealing more cards to "color_Has_Uno" for every draw action.